### PR TITLE
Added how to play section

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -20,9 +20,6 @@ plugins:
   - prettier
 rules:
   prettier/prettier: error
-  # max-len:
-  #   - error
-  #   - code: 80
   space-before-function-paren: off
   "@typescript-eslint/space-before-function-paren":
     - error
@@ -35,3 +32,4 @@ rules:
     - method
   "@typescript-eslint/no-non-null-assertion": off
   "@typescript-eslint/restrict-template-expressions": off
+  "react/no-unescaped-entities": off

--- a/apps/front/package.json
+++ b/apps/front/package.json
@@ -17,6 +17,7 @@
     "qrcode.react": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-polymorphic-box": "^3.0.3",
     "react-router-dom": "6",
     "react-use-websocket": "^4.2.0",
     "unique-names-generator": "^4.7.1",

--- a/apps/front/package.json
+++ b/apps/front/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@floating-ui/react-dom-interactions": "^0.10.1",
     "@headlessui/react": "^1.7.2",
     "@heroicons/react": "^2.0.11",
     "@knucklebones/common": "*",

--- a/apps/front/src/components/Board.tsx
+++ b/apps/front/src/components/Board.tsx
@@ -5,7 +5,7 @@ import { Dice } from './Dice'
 import { Column } from './Column'
 import { Cell } from './Cell'
 import { Name } from './Name'
-import { ColumnScore } from './ColumnScore'
+import { ColumnScoreTooltip  } from './ColumnScore'
 
 interface BoardProps extends IPlayer {
   isPlayerOne: boolean
@@ -43,7 +43,6 @@ export function Board({
       className={clsx('flex items-center gap-1 md:gap-4', {
         'flex-col': isPlayerOne,
         'flex-col-reverse': !isPlayerOne,
-        'opacity-75': !canPlay,
         'font-semibold': canPlay
       })}
     >
@@ -71,7 +70,7 @@ export function Board({
         >
           <div className='grid w-full grid-cols-3'>
             {scorePerColumn.map((score, index) => (
-              <ColumnScore
+              <ColumnScoreTooltip 
                 score={score}
                 dice={columns[index]}
                 isPlayerOne={isPlayerOne}
@@ -79,7 +78,9 @@ export function Board({
               />
             ))}
           </div>
-          <div className='grid aspect-square grid-cols-3 divide-x-2 divide-slate-300 rounded-lg bg-transparent shadow-lg shadow-slate-300 dark:divide-slate-800 dark:shadow-slate-800'>
+          <div className={clsx('grid aspect-square grid-cols-3 divide-x-2 divide-slate-300 rounded-lg bg-transparent shadow-lg shadow-slate-300 dark:divide-slate-800 dark:shadow-slate-800', {
+            'opacity-75': !canPlay
+          })}>
             {COLUMNS_PLACEHOLDER.map((_, colIndex) => {
               const column = columns[colIndex]
               const countedDice = countDiceInColumn(column)

--- a/apps/front/src/components/Board.tsx
+++ b/apps/front/src/components/Board.tsx
@@ -5,6 +5,7 @@ import { Dice } from './Dice'
 import { Column } from './Column'
 import { Cell } from './Cell'
 import { Name } from './Name'
+import { ColumnScore } from './ColumnScore'
 
 interface BoardProps extends IPlayer {
   isPlayerOne: boolean
@@ -70,9 +71,12 @@ export function Board({
         >
           <div className='grid w-full grid-cols-3'>
             {scorePerColumn.map((score, index) => (
-              <p className='text-center' key={index}>
-                {score}
-              </p>
+              <ColumnScore
+                score={score}
+                dice={columns[index]}
+                isPlayerOne={isPlayerOne}
+                key={index}
+              />
             ))}
           </div>
           <div className='grid aspect-square grid-cols-3 divide-x-2 divide-slate-300 rounded-lg bg-transparent shadow-lg shadow-slate-300 dark:divide-slate-800 dark:shadow-slate-800'>

--- a/apps/front/src/components/Board.tsx
+++ b/apps/front/src/components/Board.tsx
@@ -136,7 +136,6 @@ export function PlayerBoard({
             columns={columns}
             onColumnClick={onColumnClick}
           />
-
         </div>
         <div className='my-4'>
           <p>Total: {score}</p>

--- a/apps/front/src/components/Button.tsx
+++ b/apps/front/src/components/Button.tsx
@@ -20,7 +20,7 @@ export function Button<E extends React.ElementType = typeof defaultElement>({
       as={defaultElement}
       {...props}
       className={clsx(
-        'rounded-md border-2 border-slate-300 bg-slate-200 text-center font-medium enabled:hover:bg-slate-200/70 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-700 enabled:dark:hover:bg-slate-700/70',
+        'rounded-md border-2 border-slate-300 bg-slate-200 text-center font-medium hover:bg-slate-200/70 disabled:opacity-50 disabled:hover:bg-slate-200 dark:border-slate-600 dark:bg-slate-700 dark:hover:bg-slate-700/70 disabled:dark:hover:bg-slate-700',
         {
           'p-2 text-base': variant === 'default',
           'p-2 text-2xl md:p-4 md:text-4xl': variant === 'large',

--- a/apps/front/src/components/Button.tsx
+++ b/apps/front/src/components/Button.tsx
@@ -1,21 +1,26 @@
-import clsx from 'clsx'
 import * as React from 'react'
+import clsx from 'clsx'
+import { Box, PolymorphicComponentProps } from 'react-polymorphic-box'
 
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children: React.ReactNode
+interface ButtonProps {
   variant?: 'default' | 'large' | 'medium'
 }
+type PolymorphedButtonProps<E extends React.ElementType> =
+  PolymorphicComponentProps<E, ButtonProps>
 
-export function Button({
+const defaultElement = 'button'
+
+export function Button<E extends React.ElementType = typeof defaultElement>({
   children,
   variant = 'default',
   ...props
-}: ButtonProps) {
+}: PolymorphedButtonProps<E>) {
   return (
-    <button
+    <Box
+      as={defaultElement}
       {...props}
       className={clsx(
-        'rounded-md border-2 border-slate-300 bg-slate-200 font-medium enabled:hover:bg-slate-200/70 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-700 enabled:dark:hover:bg-slate-700/70',
+        'rounded-md border-2 border-slate-300 bg-slate-200 text-center font-medium enabled:hover:bg-slate-200/70 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-700 enabled:dark:hover:bg-slate-700/70',
         {
           'p-2 text-base': variant === 'default',
           'p-2 text-2xl md:p-4 md:text-4xl': variant === 'large',
@@ -25,6 +30,6 @@ export function Button({
       )}
     >
       {children}
-    </button>
+    </Box>
   )
 }

--- a/apps/front/src/components/ColumnScore.tsx
+++ b/apps/front/src/components/ColumnScore.tsx
@@ -16,13 +16,18 @@ interface CountedDiceProps {
 
 function CountedDice({ value, count }: CountedDiceProps) {
   if (count === 1) {
-    return <Dice value={value} count={count} variant='mini' />
+    return <Dice value={value} count={count} variant='small' />
   }
   return (
-    <p className='flex flex-row items-center'>
-      <span>({count ** 2} x</span>
-      <Dice value={value} count={count} variant='mini' className='mx-1' />
-      <span>)</span>
+    <p className='flex flex-row items-center gap-1'>
+      <span>((</span>
+      {Array.from({ length: count }).map((_, i) => (
+        <>
+          <Dice value={value} count={count} variant='small' key={i} />
+          {i + 1 < count && <span>+</span>}
+        </>
+      ))}
+      <span>) x {count})</span>
     </p>
   )
 }

--- a/apps/front/src/components/ColumnScore.tsx
+++ b/apps/front/src/components/ColumnScore.tsx
@@ -19,32 +19,61 @@ function CountedDice({ value, count }: CountedDiceProps) {
     return <Dice value={value} count={count} variant='small' />
   }
   return (
+    // TODO: div (dice) shouldn't be in p
     <p className='flex flex-row items-center gap-1'>
-      <span>((</span>
+      <span>(</span>
       {Array.from({ length: count }).map((_, i) => (
-        <>
-          <Dice value={value} count={count} variant='small' key={i} />
+        <React.Fragment key={i}>
+          <Dice value={value} count={count} variant='small' />
           {i + 1 < count && <span>+</span>}
-        </>
+        </React.Fragment>
       ))}
-      <span>) x {count})</span>
+      <span>) x {count}</span>
     </p>
   )
 }
 
 interface ColumnScoreProps {
-  isPlayerOne: boolean
   dice: number[]
   score: number
+  showScore?: boolean
 }
 
-export function ColumnScore({ dice, score, isPlayerOne }: ColumnScoreProps) {
+export function ColumnScore({
+  dice,
+  score,
+  showScore = false
+}: ColumnScoreProps) {
+  const countedDice = countDiceInColumn(dice)
+
+  return (
+    <div className='flex flex-row items-center gap-2 font-normal'>
+      {[...countedDice.entries()].map(([value, count], index) => (
+        <React.Fragment key={index}>
+          <CountedDice value={value} count={count} />
+          {index + 1 < countedDice.size && <span>+</span>}
+        </React.Fragment>
+      ))}
+      {showScore && <span> = {score}</span>}
+    </div>
+  )
+}
+
+interface ColumnScoreTooltipProps extends ColumnScoreProps {
+  isPlayerOne: boolean
+}
+
+export function ColumnScoreTooltip({
+  dice,
+  score,
+  isPlayerOne
+}: ColumnScoreTooltipProps) {
   const [showTooltip, setShowTooltip] = React.useState(false)
   const { x, y, reference, floating, strategy, context } = useFloating({
     placement: isPlayerOne ? 'top' : 'bottom',
     open: showTooltip,
     onOpenChange(open) {
-      if (score > 0) {
+      if (score > 0 || !open) {
         setShowTooltip(open)
       }
     }
@@ -55,14 +84,12 @@ export function ColumnScore({ dice, score, isPlayerOne }: ColumnScoreProps) {
     useDismiss(context)
   ])
 
-  const countedDice = countDiceInColumn(dice)
-
   return (
     <>
       <p ref={reference} className='text-center' {...getReferenceProps()}>
         {score}
       </p>
-      {showTooltip && (
+      {showTooltip && score > 0 && (
         <div
           ref={floating}
           style={{
@@ -73,14 +100,7 @@ export function ColumnScore({ dice, score, isPlayerOne }: ColumnScoreProps) {
           className='w-max rounded bg-slate-200 p-2 text-slate-900 shadow shadow-slate-300 dark:bg-slate-700 dark:text-slate-50 dark:shadow-slate-800'
           {...getFloatingProps()}
         >
-          <div className='flex flex-row items-center gap-2'>
-            {[...countedDice.entries()].map(([value, count], index) => (
-              <React.Fragment key={index}>
-                <CountedDice value={value} count={count} />
-                {index + 1 < countedDice.size && <span>+</span>}
-              </React.Fragment>
-            ))}
-          </div>
+          <ColumnScore dice={dice} score={score} />
         </div>
       )}
     </>

--- a/apps/front/src/components/ColumnScore.tsx
+++ b/apps/front/src/components/ColumnScore.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react'
+import {
+  useClick,
+  useFloating,
+  useHover,
+  useInteractions,
+  useDismiss
+} from '@floating-ui/react-dom-interactions'
+import { countDiceInColumn } from '@knucklebones/common'
+import { Dice } from './Dice'
+
+interface CountedDiceProps {
+  value: number
+  count: number
+}
+
+function CountedDice({ value, count }: CountedDiceProps) {
+  if (count === 1) {
+    return <Dice value={value} count={count} variant='mini' />
+  }
+  return (
+    <p className='flex flex-row items-center'>
+      <span>({count ** 2} x</span>
+      <Dice value={value} count={count} variant='mini' className='mx-1' />
+      <span>)</span>
+    </p>
+  )
+}
+
+interface ColumnScoreProps {
+  isPlayerOne: boolean
+  dice: number[]
+  score: number
+}
+
+export function ColumnScore({ dice, score, isPlayerOne }: ColumnScoreProps) {
+  const [showTooltip, setShowTooltip] = React.useState(false)
+  const { x, y, reference, floating, strategy, context } = useFloating({
+    placement: isPlayerOne ? 'top' : 'bottom',
+    open: showTooltip,
+    onOpenChange(open) {
+      if (score > 0) {
+        setShowTooltip(open)
+      }
+    }
+  })
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    useHover(context, { mouseOnly: true, delay: { open: 100 } }),
+    useClick(context, { ignoreMouse: true }),
+    useDismiss(context)
+  ])
+
+  const countedDice = countDiceInColumn(dice)
+
+  return (
+    <>
+      <p ref={reference} className='text-center' {...getReferenceProps()}>
+        {score}
+      </p>
+      {showTooltip && (
+        <div
+          ref={floating}
+          style={{
+            position: strategy,
+            top: y ?? 0,
+            left: x ?? 0
+          }}
+          className='w-max rounded bg-slate-200 p-2 text-slate-900 shadow shadow-slate-300 dark:bg-slate-700 dark:text-slate-50 dark:shadow-slate-800'
+          {...getFloatingProps()}
+        >
+          <div className='flex flex-row items-center gap-2'>
+            {[...countedDice.entries()].map(([value, count], index) => (
+              <React.Fragment key={index}>
+                <CountedDice value={value} count={count} />
+                {index + 1 < countedDice.size && <span>+</span>}
+              </React.Fragment>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/front/src/components/Dice.tsx
+++ b/apps/front/src/components/Dice.tsx
@@ -2,30 +2,30 @@ import * as React from 'react'
 import { clsx } from 'clsx'
 import { Transition } from '@headlessui/react'
 
-type DiceVariant = 'base' | 'mini'
-interface ClassName {
-  className?: string
-}
-
-interface DiceProps extends ClassName {
+type DiceVariant = 'base' | 'small'
+interface DiceProps {
   value: number
   count?: number
   variant?: DiceVariant
+  className?: string
+}
+interface DotProps {
+  className?: string
 }
 
 const baseClassName =
   'aspect-square h-12 portrait:md:h-16 landscape:md:h-12 landscape:lg:h-16'
-const miniClassName = 'aspect-square h-6'
+const smallClassName = 'aspect-square h-6'
 
 const VariantContext = React.createContext<DiceVariant>('base')
 
-function DicePlaceholder({ className }: ClassName) {
+function DicePlaceholder({ className }: DotProps) {
   const variant = React.useContext(VariantContext)
   return (
     <div
       className={clsx(className, {
         [baseClassName]: variant === 'base',
-        [miniClassName]: variant === 'mini'
+        [smallClassName]: variant === 'small'
       })}
     ></div>
   )
@@ -47,7 +47,7 @@ function DiceContainer({ children }: React.PropsWithChildren) {
   )
 }
 
-function Dot({ className }: ClassName) {
+function Dot({ className }: DotProps) {
   const variant = React.useContext(VariantContext)
   return (
     <div
@@ -56,7 +56,7 @@ function Dot({ className }: ClassName) {
         className,
         {
           'h-2 lg:h-3': variant === 'base',
-          'h-1': variant === 'mini'
+          'h-1': variant === 'small'
         }
       )}
     ></div>
@@ -154,7 +154,7 @@ function SimpleDice({ value, className, count = 1 }: DiceProps) {
         {
           [baseClassName]: variant === 'base',
           shadow: variant === 'base',
-          [miniClassName]: variant === 'mini'
+          [smallClassName]: variant === 'small'
         }
       )}
     >

--- a/apps/front/src/components/Dice.tsx
+++ b/apps/front/src/components/Dice.tsx
@@ -187,7 +187,7 @@ export function Dice({
     <VariantContext.Provider value={variant}>
       <Transition
         show={Boolean(value)}
-        className='transition duration-100 ease-in-out'
+        className={clsx('transition duration-100 ease-in-out', className)}
         enterFrom='opacity-0 scale-75'
         enterTo='opacity-100 scale-100'
         leaveFrom='opacity-100 scale-100'

--- a/apps/front/src/components/Game.tsx
+++ b/apps/front/src/components/Game.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react'
 import { ArrowUpIcon } from '@heroicons/react/24/solid'
 import { useGame } from '../hooks/useGame'
-import { Board } from './Board'
+import { PlayerBoard } from './Board'
 import { Logs } from './Logs'
 import { GameOutcome } from './GameOutcome'
 import { Loading } from './Loading'
 import { WarningToast } from './WarningToast'
 import { IconButton } from './IconButton'
 import { QRCodeModal } from './QRCodeModal'
+import { HowToPlayModal } from './HowToPlay'
 
 function scrollToTop() {
   window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -42,7 +43,7 @@ export function Game() {
   return (
     <div className='lg:grid-cols-3-central grid grid-cols-1'>
       <div className='h-95 flex flex-col items-center justify-evenly lg:h-screen'>
-        <Board
+        <PlayerBoard
           {...playerTwo!}
           isPlayerOne={false}
           canPlay={canPlayerTwoPlay}
@@ -56,7 +57,7 @@ export function Game() {
           }}
           isSpectator={isSpectator}
         />
-        <Board
+        <PlayerBoard
           {...playerOne!}
           isPlayerOne
           onColumnClick={canPlayerOnePlay ? sendPlay : undefined}
@@ -83,6 +84,7 @@ export function Game() {
         />
       </div>
       <QRCodeModal />
+      <HowToPlayModal />
     </div>
   )
 }

--- a/apps/front/src/components/HomePage.tsx
+++ b/apps/front/src/components/HomePage.tsx
@@ -43,11 +43,11 @@ export function HomePage() {
           show={showAiDifficulty}
           className='flex flex-row justify-center gap-4'
           enter='transition ease-in-out duration-300 transform'
-          enterFrom='opacity-0 translate-y-8'
+          enterFrom='opacity-0 -translate-y-8'
           enterTo='opacity-100 translate-y-0'
           leave='transition ease-in-out duration-300 transform'
           leaveFrom='opacity-100 translate-y-0'
-          leaveTo='opacity-0 translate-y-8'
+          leaveTo='opacity-0 -translate-y-8'
         >
           {['easy', 'medium', 'hard'].map((difficulty) => {
             return (

--- a/apps/front/src/components/HomePage.tsx
+++ b/apps/front/src/components/HomePage.tsx
@@ -1,8 +1,8 @@
+import * as React from 'react'
+import { useNavigate, Link } from 'react-router-dom'
+import { v4 as uuidv4 } from 'uuid'
 import { Transition } from '@headlessui/react'
 import { capitalize } from '@knucklebones/common'
-import * as React from 'react'
-import { useNavigate } from 'react-router-dom'
-import { v4 as uuidv4 } from 'uuid'
 import KnucklebonesLogo from '../svgs/logo.svg'
 import { Button } from './Button'
 
@@ -39,17 +39,16 @@ export function HomePage() {
         >
           Play against an AI
         </Button>
-      </div>
-      <Transition
-        show={showAiDifficulty}
-        enter='transition ease-in-out duration-300 transform'
-        enterFrom='opacity-0 translate-y-8'
-        enterTo='opacity-100 translate-y-0'
-        leave='transition ease-in-out duration-300 transform'
-        leaveFrom='opacity-100 translate-y-0'
-        leaveTo='opacity-0 translate-y-8'
-      >
-        <div className='flex flex-row gap-4'>
+        <Transition
+          show={showAiDifficulty}
+          className='flex flex-row justify-center gap-4'
+          enter='transition ease-in-out duration-300 transform'
+          enterFrom='opacity-0 translate-y-8'
+          enterTo='opacity-100 translate-y-0'
+          leave='transition ease-in-out duration-300 transform'
+          leaveFrom='opacity-100 translate-y-0'
+          leaveTo='opacity-0 translate-y-8'
+        >
           {['easy', 'medium', 'hard'].map((difficulty) => {
             return (
               <Button
@@ -66,8 +65,16 @@ export function HomePage() {
               </Button>
             )
           })}
-        </div>
-      </Transition>
+        </Transition>
+        <Button
+          as={Link}
+          variant='large'
+          className='tracking-tight'
+          to='/how-to-play'
+        >
+          How to play
+        </Button>
+      </div>
     </div>
   )
 }

--- a/apps/front/src/components/HowToPlay.tsx
+++ b/apps/front/src/components/HowToPlay.tsx
@@ -6,6 +6,7 @@ import { IconButton } from './IconButton'
 import { Modal } from './Modal'
 import { Board } from './Board'
 import { Dice } from './Dice'
+import { ColumnScore } from './ColumnScore'
 
 const SCORE_EXAMPLE_COLUMNS = [[1], [2, 2], [3, 3, 3]]
 const PLAYER_ONE_REMOVE_EXAMPLE_COLUMNS = [[], [], [6]]
@@ -45,18 +46,9 @@ function ScoreExample() {
         <ExplanationText>
           You score even more points when stacking the same dice in a column
         </ExplanationText>
-        <div className='flex flex-row items-center gap-1'>
-          <Dice value={1} count={1} variant='small' /> <span> ➝ x 1 = 1</span>
-        </div>
-        <div className='flex flex-row items-center gap-1'>
-          <Dice value={2} count={2} variant='small' />{' '}
-          <Dice value={2} count={2} variant='small' /> <span> ➝ x 2 = 8</span>
-        </div>
-        <div className='flex flex-row items-center gap-1'>
-          <Dice value={3} count={3} variant='small' />{' '}
-          <Dice value={3} count={3} variant='small' />{' '}
-          <Dice value={3} count={3} variant='small' /> <span> ➝ x 3 = 27</span>
-        </div>
+        <ColumnScore dice={[3]} score={3} showScore />
+        <ColumnScore dice={[3, 3]} score={12} showScore />
+        <ColumnScore dice={[3, 3, 3]} score={27} showScore />
       </div>
     </div>
   )

--- a/apps/front/src/components/HowToPlay.tsx
+++ b/apps/front/src/components/HowToPlay.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react'
+import clsx from 'clsx'
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline'
+import { Toolbar } from './Toolbar'
+import { IconButton } from './IconButton'
+import { Modal } from './Modal'
+import { Board } from './Board'
+import { Dice } from './Dice'
+
+const SCORE_EXAMPLE_COLUMNS = [[1], [2, 2], [3, 3, 3]]
+const PLAYER_ONE_REMOVE_EXAMPLE_COLUMNS = [[], [], [6]]
+const PLAYER_TWO_REMOVE_EXAMPLE_COLUMNS = [[], [], [6, 6]]
+
+function ExplanationText({ children }: React.PropsWithChildren) {
+  return (
+    <p className='text-center text-lg font-medium leading-tight'>{children}</p>
+  )
+}
+
+interface SeparatorProps {
+  className?: string
+}
+function Separator({ className }: SeparatorProps) {
+  return (
+    <hr
+      className={clsx(
+        'mx-8 border-slate-900/25 dark:border-slate-50/25',
+        className
+      )}
+    />
+  )
+}
+
+function ScoreExample() {
+  return (
+    <div className='flex flex-col items-center justify-center gap-8 xl:flex-row'>
+      <div className='flex-shrink-0'>
+        <Board
+          canPlay={false}
+          columns={SCORE_EXAMPLE_COLUMNS}
+          isPlayerOne={false}
+        />
+      </div>
+      <div className='grid grid-cols-1 place-items-center gap-2'>
+        <ExplanationText>
+          You score even more points when stacking the same dice in a column
+        </ExplanationText>
+        <div className='flex flex-row items-center gap-1'>
+          <Dice value={1} count={1} variant='small' /> <span> = x 1</span>
+        </div>
+        <div className='flex flex-row items-center gap-1'>
+          <Dice value={2} count={2} variant='small' />{' '}
+          <Dice value={2} count={2} variant='small' /> <span> = x 2</span>
+        </div>
+        <div className='flex flex-row items-center gap-1'>
+          <Dice value={3} count={3} variant='small' />{' '}
+          <Dice value={3} count={3} variant='small' />{' '}
+          <Dice value={3} count={3} variant='small' /> <span> = x 3</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function RemovalExample() {
+  return (
+    <div className='flex flex-col items-center justify-center gap-8 xl:flex-row'>
+      <div className='grid flex-shrink-0 grid-cols-1 gap-4'>
+        <Board
+          canPlay={false}
+          columns={PLAYER_TWO_REMOVE_EXAMPLE_COLUMNS}
+          isPlayerOne={false}
+          diceClassName='opacity-50'
+        />
+        <Board
+          canPlay={false}
+          columns={PLAYER_ONE_REMOVE_EXAMPLE_COLUMNS}
+          isPlayerOne={true}
+        />
+      </div>
+      <ExplanationText>
+        You remove all opponent's dice with the same value when placing a dice
+        in the matching column
+      </ExplanationText>
+    </div>
+  )
+}
+
+function HowToPlay() {
+  return (
+    <div className='grid grid-cols-1 gap-8'>
+      <div className='grid grid-cols-1 gap-2'>
+        <ExplanationText>
+          Each turn, you get a random dice to place in a column.
+        </ExplanationText>
+        <ExplanationText>
+          The goal is to score more points than your opponent when the game
+          ends, which happens when one of the boards is full.
+        </ExplanationText>
+      </div>
+      <Separator />
+      <div className='flex flex-col justify-center gap-4 lg:flex-row'>
+        <div className='flex flex-1 flex-row justify-center'>
+          <ScoreExample />
+        </div>
+        <Separator className='h-full border-r' />
+        <div className='flex flex-1 flex-row justify-center'>
+          <RemovalExample />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function HowToPlayPage() {
+  return (
+    <div className='container mx-auto py-8 px-4 md:px-0'>
+      <HowToPlay />
+    </div>
+  )
+}
+
+export function HowToPlayModal() {
+  const [isOpen, setOpen] = React.useState(false)
+
+  return (
+    <>
+      <Toolbar>
+        <IconButton
+          icon={<QuestionMarkCircleIcon />}
+          onClick={() => setOpen(true)}
+        />
+      </Toolbar>
+      <Modal isOpen={isOpen} onClose={() => setOpen(false)}>
+        <div className='max-w-7xl'>
+          <HowToPlay />
+        </div>
+      </Modal>
+    </>
+  )
+}

--- a/apps/front/src/components/HowToPlay.tsx
+++ b/apps/front/src/components/HowToPlay.tsx
@@ -7,7 +7,7 @@ import { Modal } from './Modal'
 import { Board } from './Board'
 import { ColumnScore } from './ColumnScore'
 
-const SCORE_EXAMPLE_COLUMNS = [[1], [2, 2], [3, 3, 3]]
+const SCORE_EXAMPLE_COLUMNS = [[3], [3, 3], [3, 3, 3]]
 const PLAYER_ONE_REMOVE_EXAMPLE_COLUMNS = [[], [], [6]]
 const PLAYER_TWO_REMOVE_EXAMPLE_COLUMNS = [[], [], [6, 6]]
 

--- a/apps/front/src/components/HowToPlay.tsx
+++ b/apps/front/src/components/HowToPlay.tsx
@@ -46,16 +46,16 @@ function ScoreExample() {
           You score even more points when stacking the same dice in a column
         </ExplanationText>
         <div className='flex flex-row items-center gap-1'>
-          <Dice value={1} count={1} variant='small' /> <span> = x 1</span>
+          <Dice value={1} count={1} variant='small' /> <span> ➝ x 1 = 1</span>
         </div>
         <div className='flex flex-row items-center gap-1'>
           <Dice value={2} count={2} variant='small' />{' '}
-          <Dice value={2} count={2} variant='small' /> <span> = x 2</span>
+          <Dice value={2} count={2} variant='small' /> <span> ➝ x 2 = 8</span>
         </div>
         <div className='flex flex-row items-center gap-1'>
           <Dice value={3} count={3} variant='small' />{' '}
           <Dice value={3} count={3} variant='small' />{' '}
-          <Dice value={3} count={3} variant='small' /> <span> = x 3</span>
+          <Dice value={3} count={3} variant='small' /> <span> ➝ x 3 = 27</span>
         </div>
       </div>
     </div>
@@ -70,7 +70,7 @@ function RemovalExample() {
           canPlay={false}
           columns={PLAYER_TWO_REMOVE_EXAMPLE_COLUMNS}
           isPlayerOne={false}
-          diceClassName='opacity-50'
+          diceClassName='opacity-75 animate-pulse'
         />
         <Board
           canPlay={false}

--- a/apps/front/src/components/HowToPlay.tsx
+++ b/apps/front/src/components/HowToPlay.tsx
@@ -5,7 +5,6 @@ import { Toolbar } from './Toolbar'
 import { IconButton } from './IconButton'
 import { Modal } from './Modal'
 import { Board } from './Board'
-import { Dice } from './Dice'
 import { ColumnScore } from './ColumnScore'
 
 const SCORE_EXAMPLE_COLUMNS = [[1], [2, 2], [3, 3, 3]]
@@ -95,7 +94,7 @@ function HowToPlay() {
         <div className='flex flex-1 flex-row justify-center'>
           <ScoreExample />
         </div>
-        <Separator className='h-full border-r' />
+        <Separator className='lg:h-full lg:border-r' />
         <div className='flex flex-1 flex-row justify-center'>
           <RemovalExample />
         </div>

--- a/apps/front/src/components/Modal.tsx
+++ b/apps/front/src/components/Modal.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import { Dialog, Transition } from '@headlessui/react'
+
+interface ModalProps {
+  isOpen: boolean
+  className?: string
+  onClose(): void
+}
+
+export function Modal({
+  isOpen,
+  children,
+  onClose
+}: React.PropsWithChildren<ModalProps>) {
+  return (
+    <Transition.Root show={isOpen}>
+      <Dialog className='relative z-10' onClose={onClose}>
+        <Transition.Child
+          enter='ease-out duration-300'
+          enterFrom='opacity-0'
+          enterTo='opacity-100'
+          leave='ease-in duration-200'
+          leaveFrom='opacity-100'
+          leaveTo='opacity-0'
+        >
+          <div className='fixed inset-0 bg-slate-900/10 bg-opacity-75 transition-opacity dark:bg-slate-50/10' />
+        </Transition.Child>
+
+        <div className='fixed inset-0 z-10 overflow-y-auto'>
+          <div className='flex min-h-full items-center justify-center p-4 text-center'>
+            <Transition.Child
+              enter='ease-out duration-300'
+              enterFrom='opacity-0 translate-y-4'
+              enterTo='opacity-100 translate-y-0'
+              leave='ease-in duration-200'
+              leaveFrom='opacity-100 translate-y-0'
+              leaveTo='opacity-0 translate-y-4'
+            >
+              <Dialog.Panel className='relative transform overflow-hidden rounded-lg bg-slate-50 p-8 text-left text-slate-900 shadow-xl transition-all dark:bg-slate-900 dark:text-slate-200'>
+                {children}
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  )
+}

--- a/apps/front/src/components/QRCode.tsx
+++ b/apps/front/src/components/QRCode.tsx
@@ -8,7 +8,7 @@ export function QRCode() {
   const { copy, copied } = useClipboard({ copiedTimeout: 750 })
 
   return (
-    <div className='flex flex-col gap-4 p-4'>
+    <div className='flex flex-col gap-4'>
       <h3 className='text-center text-xl font-medium'>
         Scan the QR Code to share the room with other players
       </h3>

--- a/apps/front/src/components/QRCodeModal.tsx
+++ b/apps/front/src/components/QRCodeModal.tsx
@@ -2,9 +2,8 @@ import * as React from 'react'
 import { QrCodeIcon } from '@heroicons/react/24/outline'
 import { Toolbar } from './Toolbar'
 import { IconButton } from './IconButton'
-import { Fragment } from 'react'
-import { Dialog, Transition } from '@headlessui/react'
 import { QRCode } from './QRCode'
+import { Modal } from './Modal'
 
 interface QRCodeModalProps {
   dismissModal?: boolean
@@ -24,39 +23,9 @@ export function QRCodeModal({ dismissModal }: QRCodeModalProps) {
       <Toolbar>
         <IconButton icon={<QrCodeIcon />} onClick={() => setOpen(true)} />
       </Toolbar>
-      <Transition.Root show={open} as={Fragment}>
-        <Dialog as='div' className='relative z-10' onClose={setOpen}>
-          <Transition.Child
-            as={Fragment}
-            enter='ease-out duration-300'
-            enterFrom='opacity-0'
-            enterTo='opacity-100'
-            leave='ease-in duration-200'
-            leaveFrom='opacity-100'
-            leaveTo='opacity-0'
-          >
-            <div className='fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity' />
-          </Transition.Child>
-
-          <div className='fixed inset-0 z-10 overflow-y-auto'>
-            <div className='flex min-h-full items-center justify-center p-4 text-center'>
-              <Transition.Child
-                as={Fragment}
-                enter='ease-out duration-300'
-                enterFrom='opacity-0 translate-y-4'
-                enterTo='opacity-100 translate-y-0'
-                leave='ease-in duration-200'
-                leaveFrom='opacity-100 translate-y-0'
-                leaveTo='opacity-0 translate-y-4'
-              >
-                <Dialog.Panel className='relative transform overflow-hidden rounded-lg bg-slate-50 text-left text-slate-900 shadow-xl transition-all dark:bg-slate-900 dark:text-slate-200'>
-                  <QRCode />
-                </Dialog.Panel>
-              </Transition.Child>
-            </div>
-          </div>
-        </Dialog>
-      </Transition.Root>
+      <Modal isOpen={open} onClose={() => setOpen(false)}>
+        <QRCode />
+      </Modal>
     </>
   )
 }

--- a/apps/front/src/components/Router.tsx
+++ b/apps/front/src/components/Router.tsx
@@ -2,12 +2,14 @@ import * as React from 'react'
 import { Routes, Route } from 'react-router-dom'
 import { Game } from './Game'
 import { HomePage } from './HomePage'
+import { HowToPlayPage } from './HowToPlay'
 
 export function Router() {
   return (
     <Routes>
       <Route path='/' element={<HomePage />} />
       <Route path='/room/:roomKey' element={<Game />} />
+      <Route path='/how-to-play' element={<HowToPlayPage />} />
       {/* Handle 404 */}
     </Routes>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,6 +290,33 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@floating-ui/core@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.1.tgz#00e64d74e911602c8533957af0cce5af6b2e93c8"
+  integrity sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==
+
+"@floating-ui/dom@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.1.tgz#3321d4e799d6ac2503e729131d07ad0e714aabeb"
+  integrity sha512-wBDiLUKWU8QNPNOTAFHiIAkBv1KlHauG2AhqjSeh2H+wR8PX+AArXfz8NkRexH5PgMJMmSOS70YS89AbWYh5dA==
+  dependencies:
+    "@floating-ui/core" "^1.0.1"
+
+"@floating-ui/react-dom-interactions@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom-interactions/-/react-dom-interactions-0.10.1.tgz#45fc7c3d9a2ae58f0ef39078660e97594f484af8"
+  integrity sha512-mb9Sn/cnPjVlEucSZTSt4Iu7NAvqnXTvmzeE5EtfdRhVQO6L94dqqT+DPTmJmbiw4XqzoyGP+Q6J+I5iK2p6bw==
+  dependencies:
+    "@floating-ui/react-dom" "^1.0.0"
+    aria-hidden "^1.1.3"
+
+"@floating-ui/react-dom@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-1.0.0.tgz#e0975966694433f1f0abffeee5d8e6bb69b7d16e"
+  integrity sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
 "@headlessui/react@^1.7.2":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.3.tgz#853c598ff47b37cdd192c5cbee890d9b610c3ec0"
@@ -803,6 +830,13 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-hidden@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.1.tgz#ad8c1edbde360b454eb2bf717ea02da00bfee0f8"
+  integrity sha512-PN344VAf9j1EAi+jyVHOJ8XidQdPVssGco39eNcsGdM4wcsILtxrKLkbuiMfLWYROK1FjRQasMWCBttrhjnr6A==
+  dependencies:
+    tslib "^2.0.0"
 
 array-includes@^3.1.4, array-includes@^3.1.5:
   version "3.1.5"
@@ -3080,7 +3114,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.2.0:
+tslib@^2.0.0, tslib@^2.2.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,6 +2730,11 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-polymorphic-box@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/react-polymorphic-box/-/react-polymorphic-box-3.0.3.tgz#4d0fe6e874a288c5c0868dce514962b100815d04"
+  integrity sha512-UUm65IGKXW7/KW4z4hyPFaQ8GMcdRMlMm3jPlU26DZ8CaWUbNP3wLD9dfjjSapgFC63uXCibtn6Th6IYd1Cm8g==
+
 react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"


### PR DESCRIPTION
- Added Modal component based on usage
- Renamed Board into PlayerBoard
- Added Board component, only showing the actual board
- Used new simple board to show examples in the HowToPlay modal
- Added HowToPlay in the toolbar while in game
- Added HowToPlay in the home page, as a page